### PR TITLE
docs: add missing `conda activate tim_env` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ git clone https://github.com/WZDTHU/TiM.git && cd TiM
 
 ```bash
 conda create -n tim_env python=3.10
+conda activate tim_env
 pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu118
 pip install flash-attn
 pip install -r requirements.txt


### PR DESCRIPTION
The installation guide was missing `conda activate tim_env` after creating the environment.
Without this, dependencies are installed into the base environment, leading to version mismatch errors.
This PR adds the missing step.